### PR TITLE
Fix quoting in s:display for bundle list

### DIFF
--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -51,7 +51,9 @@ endf
 
 func! s:display(headers, results)
   if !exists('s:browse') | let s:browse = tempname() | endif
-  let results = reverse(map(a:results, ' printf("Bundle ' ."'%s'".'", v:val) '))
+  " Build the list of bundles with the correct quoting
+  let results = reverse(map(a:results,
+        \ 'printf("Bundle ''%s''", v:val)'))
   call writefile(a:headers + results, s:browse)
   silent pedit `=s:browse`
 


### PR DESCRIPTION
## Summary
- fix quoting in the bundle list display helper

## Testing
- `apt-get update` *(fails: repository access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878bf237bf88327b537990766a6267b